### PR TITLE
Log4j2 version of MDC/ThreadContext adapter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.url
 
-addCommandAlias("ci-js",       s";clean ;logbackJS/test")
-addCommandAlias("ci-jvm",      s";clean ;logbackJVM/test")
+addCommandAlias("ci-js",       s";clean ;logbackJS/test ;log4j2JS/test")
+addCommandAlias("ci-jvm",      s";clean ;logbackJVM/test ;log4j2JVM/test")
 
 inThisBuild(List(
   organization := "io.monix",
@@ -25,11 +25,11 @@ lazy val `monix-mdc` = project.in(file("."))
   .settings(sharedSettings)
 
 lazy val rootJVM = project
-  .aggregate(logback.jvm)
+  .aggregate(logback.jvm, log4j2.jvm)
   .settings(skipOnPublishSettings)
 
 lazy val rootJS = project
-  .aggregate(logback.js)
+  .aggregate(logback.js, log4j2.js)
   .settings(skipOnPublishSettings)
 
 lazy val logback = crossProject(JSPlatform, JVMPlatform)
@@ -41,7 +41,21 @@ lazy val logback = crossProject(JSPlatform, JVMPlatform)
       "ch.qos.logback" % "logback-classic"  % "1.2.3",
       "org.scalatest"  %% "scalatest"       % "3.1.0" % Test,
       "org.scalacheck" %% "scalacheck"      % "1.14.0" % Test,
-      "io.monix"       %% "monix-eval"           % monixVersion % Test,
+      "io.monix"       %% "monix-eval"      % monixVersion % Test,
+    )
+  )
+  .enablePlugins(AutomateHeaderPlugin)
+
+lazy val log4j2 = crossProject(JSPlatform, JVMPlatform)
+  .in(file("log4j2"))
+  .settings(sharedSettings)
+  .settings(
+    name := "monix-mdc-log4j2",
+    libraryDependencies ++= Seq(
+      "org.apache.logging.log4j" % "log4j-api"        % "2.14.1",
+      "org.scalatest"            %% "scalatest"       % "3.1.0" % Test,
+      "org.scalacheck"           %% "scalacheck"      % "1.14.0" % Test,
+      "io.monix"                 %% "monix-eval"      % monixVersion % Test,
     )
   )
   .enablePlugins(AutomateHeaderPlugin)

--- a/log4j2/shared/src/main/scala/monix/mdc/MonixMDCAdapter.scala
+++ b/log4j2/shared/src/main/scala/monix/mdc/MonixMDCAdapter.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021-2021 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.mdc
+
+import monix.execution.misc.Local
+import org.apache.logging.log4j.ThreadContext
+import org.apache.logging.log4j.spi.ThreadContextMap
+
+import collection.JavaConverters._
+import java.{util => ju}
+
+class MonixMDCAdapter extends ThreadContextMap {
+  private[this] val local = Local[Map[String, String]](Map.empty[String, String])
+
+  override def put(key: String, `val`: String): Unit = local.update(local() + (key -> `val`))
+
+  override def get(key: String): String = local().getOrElse(key, null)
+
+  override def remove(key: String): Unit = local.update(local() - key)
+
+  // Note: we're resetting the Local to default, not clearing the actual hashmap
+  override def clear(): Unit = local.clear()
+
+  override def containsKey(key: String): Boolean = local().contains(key)
+
+  override def getCopy: ju.Map[String, String] = local().asJava
+
+  override def getImmutableMapOrNull: ju.Map[String, String] = {
+    if (local().isEmpty) {
+      null
+    } else {
+      getCopy
+    }
+  }
+
+  override def isEmpty: Boolean = local().isEmpty
+}
+
+object MonixMDCAdapter {
+
+  /**
+   * Initializes the [[MonixMDCAdapter]] by overriding the default ThreadContextMap. Typically
+   * you would call this once in your Main (or equivalent).
+   *
+   * NOTE: This will override the default ThreadContextMap which means that ThreadContext will
+   * no longer propagate via [[ThreadLocal]]
+   */
+  def initialize(): Unit = {
+    System.setProperty("log4j2.threadContextMap", "monix.mdc.MonixMDCAdapter")
+  }
+
+  private[this] def productToMap[T <: Product](product: T): Map[String, String] = {
+    val fields = product.getClass.getDeclaredFields.map(_.getName)
+    val values = product.productIterator.toSeq.map {
+      case maybe: Option[_] => maybe
+      case value => Option(value)
+    }
+    fields.zip(values).collect { case (k, Some(v)) => (k, v.toString) }.toMap
+  }
+
+  /*
+   * Set the diagnostic context with the values of the given
+   * product with its respective field names as the keys.
+   *
+   * The current context will be fully overwritten with the new values.
+   */
+  def setContext[T <: Product](product: T): Unit = {
+    ThreadContext.clearAll()
+    ThreadContext.putAll(productToMap(product).asJava)
+  }
+
+  /**
+   * Puts the values of the given product with its respective
+   * field names as the keys into the diagnostic context.
+   *
+   * The current context will remain the same, but only the
+   * fields that already existed will be overwritten.
+   */
+  def updateContext[T <: Product](product: T): Unit = {
+    productToMap(product).foreach(kv => ThreadContext.put(kv._1, kv._2))
+  }
+
+}

--- a/log4j2/shared/src/test/scala/monix/mdc/InitializeMDC.scala
+++ b/log4j2/shared/src/test/scala/monix/mdc/InitializeMDC.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021-2021 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.mdc
+
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait InitializeMDC extends BeforeAndAfterAll { this: Suite =>
+  override def beforeAll(): Unit =
+    MonixMDCAdapter.initialize()
+}

--- a/log4j2/shared/src/test/scala/monix/mdc/KeyValue.scala
+++ b/log4j2/shared/src/test/scala/monix/mdc/KeyValue.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021-2021 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.mdc
+
+import org.scalacheck.{Arbitrary, Gen}
+
+final case class KeyValue(key: String, value: String)
+
+object KeyValue {
+  lazy val keyValueGenerator: Gen[KeyValue] = for {
+    key   <- Gen.alphaStr
+    value <- Gen.alphaStr
+  } yield KeyValue(key, value)
+
+  implicit val arbKeyValue: Arbitrary[KeyValue] = Arbitrary(keyValueGenerator)
+}

--- a/log4j2/shared/src/test/scala/monix/mdc/MDCBasicSpec.scala
+++ b/log4j2/shared/src/test/scala/monix/mdc/MDCBasicSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021-2021 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.mdc
+
+import monix.eval.{Task, TaskLocal}
+import monix.execution.Scheduler
+import org.apache.logging.log4j.ThreadContext
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.concurrent.ExecutionContext
+
+class MDCBasicSpec extends AsyncWordSpec with Matchers with InitializeMDC with BeforeAndAfter {
+  implicit val scheduler: Scheduler               = Scheduler.global
+  override def executionContext: ExecutionContext = scheduler
+  implicit val opts: Task.Options                 = Task.defaultOptions.enableLocalContextPropagation
+
+  before {
+    ThreadContext.clearMap()
+  }
+
+  def putAndGet(key: String, value: String): Task[String] =
+    for {
+      _ <- Task {
+        ThreadContext.put(key, value)
+      }
+      get <- Task {
+        ThreadContext.get(key)
+      }
+    } yield get
+
+  "Task with ThreadContext" can {
+    "Write and get a value" in {
+      val keyValue = KeyValue.keyValueGenerator.sample.get
+
+      val task = putAndGet(keyValue.key, keyValue.value)
+      task.runToFutureOpt.map { _ shouldBe keyValue.value }
+    }
+
+    "Write and get different values concurrently" in {
+      val keyValues = MultipleKeysMultipleValues.multipleKeyValueGenerator.sample.get
+
+      val tasks = keyValues.keysAndValues.map { keyValue =>
+        TaskLocal.isolate(putAndGet(keyValue.key, keyValue.value).executeAsync)
+      }
+
+      val task = Task.parSequence(tasks)
+
+      task.runToFutureOpt.map { retrievedKeyValues =>
+        retrievedKeyValues.size shouldBe keyValues.keysAndValues.size
+        retrievedKeyValues shouldBe keyValues.keysAndValues.map(_.value)
+      }
+    }
+
+    "Isolate nested modifications" in {
+
+      val test = for {
+        // to initialize the map
+        _ <- Task(ThreadContext.put("key", "0"))
+        _ <- TaskLocal.isolate(Task(ThreadContext.put("key", "1")))
+      } yield ThreadContext.get("key") shouldBe "0"
+
+      test.runToFutureOpt
+    }
+
+  }
+}

--- a/log4j2/shared/src/test/scala/monix/mdc/MDCFutureSpec.scala
+++ b/log4j2/shared/src/test/scala/monix/mdc/MDCFutureSpec.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2021-2021 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.mdc
+
+import monix.eval.Task
+import monix.execution.misc.Local
+import monix.execution.schedulers.TracingScheduler
+import org.apache.logging.log4j.ThreadContext
+import org.scalatest.{Assertion, BeforeAndAfter}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class MDCFutureSpec extends AsyncWordSpec with Matchers with InitializeMDC with BeforeAndAfter {
+  implicit val scheduler: TracingScheduler = TracingScheduler(ExecutionContext.global)
+
+  override def executionContext: ExecutionContext = scheduler
+
+  implicit val opts: Task.Options = Task.defaultOptions.enableLocalContextPropagation
+
+  before {
+    ThreadContext.clearMap()
+  }
+
+    "Mixing Task with Future" can {
+      "Write with Task and get in Future" in {
+        val keyValue = KeyValue.keyValueGenerator.sample.get
+
+        val task = for {
+          _ <- Task {
+                ThreadContext.put(keyValue.key, keyValue.value)
+              }
+          get <- Task.fromFuture {
+                  Future {
+                    ThreadContext.get(keyValue.key)
+                  }
+                }
+        } yield get
+
+        task.runToFutureOpt.map { _ shouldBe keyValue.value }
+      }
+
+      "Write with Task and get in Future inside Future for comprehension" in {
+        val keyValue = KeyValue.keyValueGenerator.sample.get
+
+        val future = for {
+          _ <- Task {
+                ThreadContext.put(keyValue.key, keyValue.value)
+              }.runToFutureOpt
+          get <- Future {
+                  ThreadContext.get(keyValue.key)
+                }
+        } yield get
+
+        future.map { _ shouldBe keyValue.value }
+      }
+
+      "Write with Future and get in Task" in {
+        val keyValue = KeyValue.keyValueGenerator.sample.get
+
+        val task = for {
+          _ <- Task.deferFuture {
+                Future {
+                  ThreadContext.put(keyValue.key, keyValue.value)
+                }
+              }
+          get <- Task {
+                  ThreadContext.get(keyValue.key)
+                }
+        } yield get
+
+        task.runToFutureOpt.map { _ shouldBe keyValue.value }
+      }
+
+      def getAndPutTask(key: String, value: String): Future[String] =
+        for {
+          _ <- Task {
+            ThreadContext.put(key, value)
+            Local.getContext()
+          }.runToFutureOpt
+          get <- Future {
+            assert(ThreadContext.getImmutableContext.size == 1)
+            ThreadContext.get(key)
+          }
+        } yield get
+
+      "Write with Task and get in Future inside Future for comprehension concurrently" in {
+        (0 to 1000).foldLeft[Future[Assertion]](Future.successful(1 shouldBe 1)) { case (lastAssertion, _) =>
+          val keyValues = MultipleKeysMultipleValues.multipleKeyValueGenerator.sample.get
+
+          val f = lastAssertion
+
+          val futures = keyValues.keysAndValues.map { keyValue =>
+            getAndPutTask(keyValue.key, keyValue.value)
+          }
+
+
+          val future: Future[Set[String]] =
+            f.flatMap(_ => Future.sequence(futures))
+
+           future.map { retrievedKeyValues =>
+            retrievedKeyValues shouldBe keyValues.keysAndValues.map(_.value)
+          }
+        }
+      }
+    }
+
+    def getAndPut(key: String, value: String): Future[String] =
+      for {
+        _ <- Future {
+              ThreadContext.put(key, value)
+            }
+        get <- Future {
+                ThreadContext.get(key)
+              }
+      } yield get
+
+    "Using Future only" can {
+      "Write and get a value" in {
+        val keyValue = KeyValue.keyValueGenerator.sample.get
+
+        val future = getAndPut(keyValue.key, keyValue.value)
+
+        future.map { _ shouldBe keyValue.value }
+      }
+
+      "Write and get different values concurrently" in {
+        val keyValues = MultipleKeysMultipleValues.multipleKeyValueGenerator.sample.get
+
+        val futures = keyValues.keysAndValues.map { keyValue =>
+          Local.isolate(getAndPut(keyValue.key, keyValue.value))
+        }
+
+        val future = Future.sequence(futures)
+
+        future.map { retrievedKeyValues =>
+          retrievedKeyValues.size shouldBe keyValues.keysAndValues.size
+          retrievedKeyValues shouldBe keyValues.keysAndValues.map(_.value)
+        }
+      }
+    }
+}

--- a/log4j2/shared/src/test/scala/monix/mdc/MDCProductSpec.scala
+++ b/log4j2/shared/src/test/scala/monix/mdc/MDCProductSpec.scala
@@ -21,8 +21,8 @@ import monix.eval.Task
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
-import org.slf4j.MDC
 import monix.execution.Scheduler.Implicits.global
+import org.apache.logging.log4j.ThreadContext
 
 import java.time.Instant
 
@@ -47,17 +47,17 @@ class MDCProductSpec extends AsyncWordSpec with Matchers {
       val staticFieldName = "staticFieldName"
       val staticValueName = "staticValueName"
 
-      Task(MDC.put(staticFieldName, staticValueName)) *>
-        Task(MDC.get(staticFieldName) shouldBe staticValueName) *>
+      Task(ThreadContext.put(staticFieldName, staticValueName)) *>
+        Task(ThreadContext.get(staticFieldName) shouldBe staticValueName) *>
         Task(MonixMDCAdapter.setContext(metadataCtx)) *>
         Task.eval {
-          MDC.get("idString") shouldBe metadataCtx.idString
-          MDC.get("idInt") shouldBe metadataCtx.idInt.toString
-          MDC.get("timestamp") shouldBe metadataCtx.timestamp.toString
-          MDC.get("other") shouldBe metadataCtx.other.toString
+          ThreadContext.get("idString") shouldBe metadataCtx.idString
+          ThreadContext.get("idInt") shouldBe metadataCtx.idInt.toString
+          ThreadContext.get("timestamp") shouldBe metadataCtx.timestamp.toString
+          ThreadContext.get("other") shouldBe metadataCtx.other.toString
           // the value is `null` because `setContext` is overwriting it
-          MDC.get(staticFieldName) shouldBe null
-          MDC.get("random") shouldBe null
+          ThreadContext.get(staticFieldName) shouldBe null
+          ThreadContext.get("random") shouldBe null
         }
     }.runToFuture
 
@@ -67,22 +67,22 @@ class MDCProductSpec extends AsyncWordSpec with Matchers {
       val staticValueName = "staticValueName"
       val randomId = Gen.identifier.sample.get
 
-      Task(MDC.put(staticFieldName, staticValueName)) *>
-        Task(MDC.put("idString", randomId)) *>
+      Task(ThreadContext.put(staticFieldName, staticValueName)) *>
+        Task(ThreadContext.put("idString", randomId)) *>
         Task{
-          MDC.get(staticFieldName) shouldBe staticValueName
-          MDC.get("idString") shouldBe randomId
+          ThreadContext.get(staticFieldName) shouldBe staticValueName
+          ThreadContext.get("idString") shouldBe randomId
         } *>
         Task(MonixMDCAdapter.updateContext(metadataCtx)) *>
         Task.eval {
-          MDC.get("idString") shouldBe metadataCtx.idString
-          MDC.get("idInt") shouldBe metadataCtx.idInt.toString
-          MDC.get("timestamp") shouldBe metadataCtx.timestamp.toString
-          MDC.get("other") shouldBe metadataCtx.other.toString
+          ThreadContext.get("idString") shouldBe metadataCtx.idString
+          ThreadContext.get("idInt") shouldBe metadataCtx.idInt.toString
+          ThreadContext.get("timestamp") shouldBe metadataCtx.timestamp.toString
+          ThreadContext.get("other") shouldBe metadataCtx.other.toString
 
           //the static field name is persisted since we were updating
-          MDC.get(staticFieldName) shouldBe staticValueName
-          MDC.get("random") shouldBe null
+          ThreadContext.get(staticFieldName) shouldBe staticValueName
+          ThreadContext.get("random") shouldBe null
         }
     }.runToFuture
 
@@ -91,10 +91,10 @@ class MDCProductSpec extends AsyncWordSpec with Matchers {
 
       Task.evalAsync(MonixMDCAdapter.setContext(metadataCtx)) >>
         Task {
-          Option(MDC.get("idString")) shouldBe None
-          Option(MDC.get("idInt")) shouldBe Some("1")
-          Option(MDC.get("timestamp")) shouldBe None
-          MDC.get("other") shouldBe metadataCtx.other.toString
+          Option(ThreadContext.get("idString")) shouldBe None
+          Option(ThreadContext.get("idInt")) shouldBe Some("1")
+          Option(ThreadContext.get("timestamp")) shouldBe None
+          ThreadContext.get("other") shouldBe metadataCtx.other.toString
         }
     }.runToFuture
 

--- a/log4j2/shared/src/test/scala/monix/mdc/MultipleKeysMultipleValues.scala
+++ b/log4j2/shared/src/test/scala/monix/mdc/MultipleKeysMultipleValues.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021-2021 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.mdc
+
+import org.scalacheck.{Arbitrary, Gen}
+
+final case class MultipleKeysMultipleValues(keysAndValues: Set[KeyValue])
+
+object MultipleKeysMultipleValues {
+  lazy val multipleKeyValueGenerator: Gen[MultipleKeysMultipleValues] =
+    for {
+      range     <- Gen.chooseNum(2, 10)
+      keyValues <- Gen.containerOfN[Set, KeyValue](range, KeyValue.keyValueGenerator)
+    } yield MultipleKeysMultipleValues(keyValues)
+
+  implicit val arbMultipleKeyValue: Arbitrary[MultipleKeysMultipleValues] = Arbitrary(multipleKeyValueGenerator)
+}


### PR DESCRIPTION
Log4j2 version of the context map being overridden. This integrates with the `ThreadContext` interface instead of the `MDC` interface even though many people still refer to it as `MDC`. If the naming is confusing, I'm happy open a PR to another repo.